### PR TITLE
TEC-4456: Support wisper 3.0 broadcaster interface

### DIFF
--- a/lib/wisper/active_job/listener.rb
+++ b/lib/wisper/active_job/listener.rb
@@ -9,8 +9,8 @@ module Wisper
           "Please ensure your class has ActiveJob::Base in its ancestry (either directly or via e.g. ApplicationJob)")
       end
 
-      def perform(event_name, args)
-        self.class.public_send(event_name, *args)
+      def perform(event_name, args, kwargs = {})
+        self.class.public_send(event_name, *args, **kwargs.symbolize_keys)
       end
     end
   end

--- a/lib/wisper/active_job/version.rb
+++ b/lib/wisper/active_job/version.rb
@@ -1,5 +1,5 @@
 module Wisper
   module ActiveJob
-    VERSION = "1.1.0.pre"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/wisper/active_job_broadcaster.rb
+++ b/lib/wisper/active_job_broadcaster.rb
@@ -4,20 +4,20 @@ require 'active_job'
 
 module Wisper
   class ActiveJobBroadcaster
-    def broadcast(subscriber, publisher, event, args)
+    def broadcast(subscriber, publisher, event, *args, **kwargs)
       if subscriber < ActiveJob::Listener
-        subscriber.perform_later(event, args)
+        subscriber.perform_later(event, args, kwargs)
       else
-        Wrapper.perform_later(subscriber.name, event, args)
+        Wrapper.perform_later(subscriber.name, event, args, kwargs)
       end
     end
 
     class Wrapper < ::ActiveJob::Base
       queue_as :default
 
-      def perform(class_name, event, args)
+      def perform(class_name, event, args, kwargs = {})
         listener = class_name.constantize
-        listener.public_send(event, *args)
+        listener.public_send(event, *args, **kwargs.symbolize_keys)
       end
     end
 

--- a/spec/active_job/listener_spec.rb
+++ b/spec/active_job/listener_spec.rb
@@ -14,11 +14,23 @@ RSpec.describe Wisper::ActiveJob::Listener do
       def self.my_event(arg1, arg2)
         [arg1, arg2]
       end
+
+      def self.my_kwargs_event(arg1, key:)
+        [arg1, key]
+      end
     end
   }
 
   it 'defines a #perform method that calls the expected class methods with arguments splatted' do
     expect(listener.new.perform("my_event", [1, 2])).to eq([1, 2])
     expect(listener.new.perform(:my_event, [1, 2])).to eq([1, 2])
+  end
+
+  it 'supports keyword arguments' do
+    expect(listener.new.perform("my_kwargs_event", [1], { "key" => 2 })).to eq([1, 2])
+  end
+
+  it 'defaults kwargs to empty hash for backward compatibility' do
+    expect(listener.new.perform("my_event", [1, 2], {})).to eq([1, 2])
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'integration tests:' do
   end
 
   context 'when the subscriber is a plain old ruby class' do
-    it 'enqueues Wrapper ActiveJob with nil, event name and args array' do
+    it 'enqueues Wrapper ActiveJob with nil, event name, args array, and kwargs hash' do
       publisher.subscribe(subscriber, async: Wisper::ActiveJobBroadcaster.new)
 
       publisher.run
@@ -41,12 +41,12 @@ RSpec.describe 'integration tests:' do
       expect(adapter.enqueued_jobs.size).to eq 1
       job = adapter.enqueued_jobs.first
       expect(job['job_class']).to eq 'Wisper::ActiveJobBroadcaster::Wrapper'
-      expect(job['arguments']).to eq [nil, 'it_happened', ['hello, world']]
+      expect(job['arguments']).to eq [nil, 'it_happened', ['hello, world'], {}]
     end
   end
 
   context 'when the subscriber extends ActiveJob' do
-    it 'enqueues subscriber ActiveJob with event name and args array' do
+    it 'enqueues subscriber ActiveJob with event name, args array, and kwargs hash' do
       publisher.subscribe(DummyActiveJobSubscriber, async: Wisper::ActiveJobBroadcaster.new)
 
       publisher.run
@@ -54,7 +54,7 @@ RSpec.describe 'integration tests:' do
       expect(adapter.enqueued_jobs.size).to eq 1
       job = adapter.enqueued_jobs.first
       expect(job['job_class']).to eq 'DummyActiveJobSubscriber'
-      expect(job['arguments']).to eq ['it_happened', ['hello, world']]
+      expect(job['arguments']).to eq ['it_happened', ['hello, world'], {}]
     end
   end
 end


### PR DESCRIPTION
## [TEC-4456](https://immersivelabsuk.atlassian.net/browse/TEC-4456)

Previously, wisper 2.x passed event arguments to broadcasters as a single Array. Wisper 3.0 splats them as individual positional arguments plus keyword arguments. This caused argument count mismatches in the broadcaster's `broadcast` method.

Updated the broadcaster signature to accept `*args, **kwargs`, collect them back into an array and hash, and pass both through ActiveJob. Added `.symbolize_keys` on the receive side since ActiveJob serializes symbol keys as strings.

[TEC-4456]: https://immersivelabsuk.atlassian.net/browse/TEC-4456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ